### PR TITLE
Test - uncommitted changes by make all should fail CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Check go versions
         uses: enterprise-contract/github-workflows/golang-version-check@main
 
+      - name: Build all
+        run: make all
+
       - name: Test
         run: make test
 
@@ -69,6 +72,7 @@ jobs:
           if ! git diff --exit-code -s; then
             for f in $(git diff --exit-code --name-only); do
               echo "::error file=$f,line=1,col=1,endColumn=1::File was modified in build"
+              echo -e "\033[1;33mHint:\033[0m Maybe you need to run \033[1;32mmake all\033[0m"
             done
             exit 1
           fi

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -201,11 +201,7 @@ Appears In: xref:{anchor_prefix}-github-com-enterprise-contract-enterprise-contr
 | *`value`* __string__ | 
 | *`effectiveOn`* __string__ | 
 | *`effectiveUntil`* __string__ | 
-| *`imageRef`* __string__ | DEPRECATED: Use ImageDigest instead +
-ImageRef is used to specify an image by its digest. +
-| *`imageDigest`* __string__ | ImageDigest is used to specify an image by its digest. +
-| *`imageUrl`* __string__ | ImageUrl is used to specify an image by its URL without a tag. +
-| *`reference`* __string__ | Reference is used to include a link to related information such as a Jira issue URL. +
+| *`imageRef`* __string__ | ImageRef is used to specify an image by its digest. +
 |===
 
 


### PR DESCRIPTION
This PR is to validate https://github.com/enterprise-contract/enterprise-contract-controller/pull/525.

Running make all from this PR should generate uncommitted files. This is intentional, to see if the new CI test will catch that and fail.

### DO NOT MERGE!